### PR TITLE
Fix typo in api deployment template

### DIFF
--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: NODE_ENV
           value: "production"
-        {{- if .Values.global.mongoUrl }}
+        {{- if .Values.api.mailUrl }}
         - name: MAIL_URL
           value: {{ .Values.api.mailUrl }}
         {{- end }}


### PR DESCRIPTION
The api deployment template has a typo using the mongo url instead of the api mail url