### PR TITLE
Move playground introspection options to api

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: reactioncommerce
 home: https://reactioncommerce.com/
-version: 0.2.2
+version: 0.2.3
 appVersion: 3.9.0
 description: Reaction Commerce is an API-first, modular commerce 
  stack made for ambitious brands and retailers. Reaction’s

--- a/templates/admin/admin-configmap.yml
+++ b/templates/admin/admin-configmap.yml
@@ -24,6 +24,4 @@ data:
   PUBLIC_I18N_BASE_URL: {{ include "reactioncommerce.api.url" . | quote }}
   PUBLIC_STOREFRONT_HOME_URL: {{ include "reactioncommerce.web.url" . | quote }}
   ROOT_URL: {{ include "reactioncommerce.admin.url" . | quote }}
-  GRAPHQL_PLAYGROUND_ENABLED: {{ .Values.api.enableGraphQlPlayground | default "false" | quote }}
-  GRAPHQL_INTROSPECTION_ENABLED: {{ .Values.api.enableGraphQlIntrospection | default "false" | quote }}
 {{- end }}

--- a/templates/api/api-configmap.yml
+++ b/templates/api/api-configmap.yml
@@ -20,4 +20,6 @@ data:
   ROOT_URL: {{ include "reactioncommerce.api.url" . | quote }}
   REACTION_SHOULD_INIT_REPLICA_SET: {{ .Values.api.initReplicaSet | default "false" | quote }}
   HYDRA_OAUTH2_INTROSPECT_URL: {{ printf "%s/oauth2/introspect" ( include "reactioncommerce.hydra.admin.url" . ) | quote }}
+  GRAPHQL_PLAYGROUND_ENABLED: {{ .Values.api.enableGraphQlPlayground | default "false" | quote }}
+  GRAPHQL_INTROSPECTION_ENABLED: {{ .Values.api.enableGraphQlIntrospection | default "false" | quote }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Moves the graphql playground and introspection query options to the api configmap.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
