### PR TITLE
Switch out mainline helm stable repo

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -5,5 +5,5 @@ dependencies:
     condition: mongodb.enabled
   - name: postgresql
     version: 8.1.4
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: postgresql.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:
Google's cache of the stable helm repo is dead - this pr switches to the official one.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
